### PR TITLE
fix link to download amb binaries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ npm -g install @ambientum/cli
 Option 2: Using pre-built binaries at https://github.com/ambientum/cli/releases/tag/0.1.1:
 
 ```
-curl -L https://github.com/ambientum/cli/releases/download/v0.1.1/amb-`uname -s` -o /usr/local/bin/amb
+sudo curl -L "https://github.com/ambientum/cli/releases/download/0.1.1/amb-$(uname -s | tr "[:upper:]" "[:lower:]")" -o /usr/local/bin/amb
 chmod +x /usr/local/bin/amb
 ```
 


### PR DESCRIPTION
The current link try to get the binaries files from wrong version tag  "v0.1.1", and the command `uname -s` get an uppercase string, and this make occur erros when try download. This PR fix the link to the correct version tag "0.1.1" and transform the output of `uname -s` command in lowercase letters.