### PR TITLE
Add auto-start configuration in xdebug.

### DIFF
--- a/php/7.3/start.sh
+++ b/php/7.3/start.sh
@@ -48,6 +48,7 @@ if [[ $XDEBUG_ENABLED == true ]]; then
     echo "xdebug.remote_enable=1" | sudo tee -a /etc/php7/conf.d/00_xdebug.ini > /dev/null
     echo "xdebug.remote_host=`/sbin/ip route|awk '/default/ { print $3 }'`" | sudo tee -a /etc/php7/conf.d/00_xdebug.ini > /dev/null
     echo "xdebug.remote_port=9000" | sudo tee -a /etc/php7/conf.d/00_xdebug.ini > /dev/null
+    echo "xdebug.remote_autostart=1" | sudo tee -a /etc/php7/conf.d/00_xdebug.ini > /dev/null
     echo "xdebug.scream=0" | sudo tee -a /etc/php7/conf.d/00_xdebug.ini > /dev/null
     echo "xdebug.cli_color=1" | sudo tee -a /etc/php7/conf.d/00_xdebug.ini > /dev/null
     echo "xdebug.show_local_vars=1" | sudo tee -a /etc/php7/conf.d/00_xdebug.ini > /dev/null


### PR DESCRIPTION
I made this change to enable the debug in places where it is not possible to send the cookie, for example: commands, tests, etc.
I made this modification locally and I'm testing it for a few days, and it has helped me a lot to debug commands (CLI), tests, and anything.

I believe this will not cause any unexpected behavior since it will only activate if the variable "$ XDEBUG_ENABLED" is set to TRUE.

If the developer does not want to debug the code, it can simply disable listening on the IDE.

Thanks for the work done on this project @hernandev !